### PR TITLE
Add interactive style guide, theme tokens and persistent theme toggle

### DIFF
--- a/demo-components.html
+++ b/demo-components.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo Components • Calcule Já</title>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@600&display=swap');
+
+      :root,
+      :root[data-theme='light'] {
+        --surface-base: #f7f7f5;
+        --surface-raised: #ffffff;
+        --surface-overlay: #ffffff;
+        --surface-sunken: #ecefe7;
+        --text-primary: #111218;
+        --text-secondary: #4e5362;
+        --text-tertiary: #8d93a5;
+        --text-disabled: #b3b7c2;
+        --text-inverse: #0f111b;
+        --border-subtle: #d9deeb;
+        --border-default: #c4cbda;
+        --border-strong: #677ef4;
+        --border-accent: #677ef4;
+        --accent-primary: #677ef4;
+        --accent-primary-dim: rgba(103, 126, 244, 0.2);
+        --accent-success: #14a26d;
+        --accent-error: #e14e66;
+        --accent-warning: #d89a1b;
+        --shadow-sm: 0 10px 24px rgba(65, 85, 140, 0.14);
+        --shadow-md: 0 24px 60px rgba(57, 74, 129, 0.2);
+        --shadow-glow: 0 0 0 1px rgba(103, 126, 244, 0.35), 0 16px 36px rgba(103, 126, 244, 0.2);
+        --z-base: 0;
+        --z-raised: 10;
+        --z-dropdown: 100;
+        --z-sticky: 200;
+        --z-modal: 300;
+        --z-toast: 400;
+        --z-tooltip: 500;
+      }
+
+      :root[data-theme='dark'] {
+        --surface-base: #0f1117;
+        --surface-raised: #181b23;
+        --surface-overlay: #1d222d;
+        --surface-sunken: #12161f;
+        --text-primary: #edeee8;
+        --text-secondary: #afb5c8;
+        --text-tertiary: #80879f;
+        --text-disabled: #5e657f;
+        --text-inverse: #f1f3fb;
+        --border-subtle: #2a2f3f;
+        --border-default: #333b50;
+        --border-strong: #8d9bff;
+        --border-accent: #8d9bff;
+        --accent-primary: #8d9bff;
+        --accent-primary-dim: rgba(141, 155, 255, 0.22);
+        --accent-success: #33bc8e;
+        --accent-error: #ff7087;
+        --accent-warning: #e9b04e;
+        --shadow-sm: 0 15px 34px rgba(4, 8, 20, 0.55);
+        --shadow-md: 0 30px 70px rgba(2, 4, 11, 0.8);
+        --shadow-glow: 0 0 0 1px rgba(141, 155, 255, 0.38), 0 16px 40px rgba(82, 94, 181, 0.28);
+      }
+
+      *,*::before,*::after{box-sizing:border-box;transition:background-color 220ms ease,border-color 220ms ease,color 160ms ease,box-shadow 220ms ease}
+      img,video,[data-no-transition]{transition:none}
+      body{margin:0;font-family:Inter,sans-serif;color:var(--text-primary);background:radial-gradient(circle at 20% 8%,rgba(103,126,244,.11),transparent 40%),radial-gradient(circle at 86% 4%,rgba(216,154,27,.12),transparent 35%),radial-gradient(circle,rgba(136,144,166,.15) 1px,transparent 1px),var(--surface-base);background-size:auto,auto,20px 20px,auto;padding:24px}
+      :root[data-theme='dark'] body{background:radial-gradient(circle at 16% 12%,rgba(141,155,255,.09),transparent 45%),radial-gradient(circle at 86% 0%,rgba(167,112,255,.08),transparent 36%),radial-gradient(circle at 44% 100%,rgba(51,188,142,.06),transparent 44%),var(--surface-base)}
+      .demo{max-width:1200px;margin:0 auto;display:grid;gap:20px}
+      .card{background:var(--surface-raised);border:1px solid var(--border-subtle);border-radius:20px;padding:24px;box-shadow:var(--shadow-sm)}
+      h1,h2{margin:0 0 14px} h1{font-size:2rem} h2{font-size:1.25rem}
+      .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px}
+      .theme-toggle{width:52px;height:28px;border-radius:99px;border:1px solid var(--border-subtle);background:linear-gradient(130deg,#76ccff,#94a5ff);padding:2px;position:relative;cursor:pointer}
+      .theme-thumb{position:absolute;top:2px;left:2px;width:24px;height:24px;border-radius:50%;background:var(--surface-raised);display:grid;place-items:center;transition:transform 260ms cubic-bezier(0.34,1.56,0.64,1)}
+      .theme-star{position:absolute;width:2px;height:2px;background:#fff;border-radius:50%;opacity:0;transform:translateY(4px)}
+      :root[data-theme='dark'] .theme-toggle{background:linear-gradient(130deg,#3747a0,#7a47d8)}
+      :root[data-theme='dark'] .theme-thumb{transform:translateX(24px)}
+      :root[data-theme='dark'] .theme-star{opacity:.7;animation:twinkle 1.8s ease-in-out infinite}
+
+      .input-wrapper{position:relative;padding-top:8px}
+      .input-field{position:relative;display:flex;align-items:center;background:var(--surface-sunken);border:1px solid var(--border-default);border-radius:14px;padding:20px 14px 10px;gap:8px}
+      .input-field::after{content:'';position:absolute;left:50%;right:50%;bottom:0;height:2px;background:var(--accent-primary);transition:left 220ms ease,right 220ms ease}
+      .input-wrapper:focus-within .input-field::after{left:0;right:0}
+      .input-wrapper:focus-within .input-field{border-color:var(--border-strong);box-shadow:0 0 0 3px var(--accent-primary-dim)}
+      .input-control,.textarea-control{width:100%;border:0;background:transparent;color:var(--text-primary);outline:0;font:inherit}
+      .input-label{position:absolute;left:16px;top:28px;transform:translateY(-50%);font-size:1rem;color:var(--text-tertiary);pointer-events:none;transition:top 180ms cubic-bezier(.4,0,.2,1),font-size 180ms cubic-bezier(.4,0,.2,1),color 180ms ease,transform 180ms cubic-bezier(.4,0,.2,1)}
+      .input-wrapper:focus-within .input-label,.input-wrapper.is-filled .input-label{top:16px;transform:none;font-size:.72rem;color:var(--accent-primary);font-weight:500}
+      .hint{font-size:.78rem;color:var(--text-tertiary);margin-top:6px;min-height:1em}
+      .input-wrapper.is-error .input-field{border-color:var(--accent-error);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent-error) 22%,transparent);animation:shake 300ms ease}
+      .input-wrapper.is-success .input-field{border-color:var(--accent-success)}
+      .input-wrapper.is-loading .input-field{pointer-events:none;opacity:.75}
+      .status-icon{opacity:0;transform:scale(.6);transition:transform 150ms ease,opacity 150ms ease}
+      .input-wrapper.is-error .error-icon,.input-wrapper.is-success .success-icon,.input-wrapper.is-loading .loader{opacity:1;transform:scale(1)}
+      .loader{width:16px;height:16px;border:2px solid var(--border-default);border-top-color:var(--accent-primary);border-radius:50%;animation:spin .8s linear infinite}
+      .success-icon svg{width:18px;height:18px;stroke:var(--accent-success);fill:none;stroke-width:2;stroke-dasharray:20;stroke-dashoffset:20;animation:draw .35s ease forwards}
+
+      .custom-select{position:relative}.select-trigger{width:100%;padding:12px 14px;border-radius:12px;background:var(--surface-sunken);border:1px solid var(--border-default);display:flex;justify-content:space-between;cursor:pointer}
+      .chevron{transition:transform 220ms ease}.custom-select.open .chevron{transform:rotate(180deg)}
+      .select-menu{display:none;position:absolute;top:calc(100% + 8px);left:0;right:0;background:var(--surface-overlay);border:1px solid var(--border-subtle);border-radius:12px;padding:8px;z-index:var(--z-dropdown);box-shadow:var(--shadow-md)}
+      .custom-select.open .select-menu{display:block;animation:fadeSlide .18s ease}
+      .option{padding:10px;border-radius:8px;cursor:pointer}.option:hover{background:var(--accent-primary-dim)}
+
+      .range-wrap{position:relative}.range{width:100%;appearance:none;height:6px;background:linear-gradient(90deg,var(--accent-primary) var(--fill,35%),var(--border-subtle) var(--fill,35%));border-radius:999px;outline:none}
+      .range::-webkit-slider-thumb{appearance:none;width:18px;height:18px;border-radius:50%;background:var(--surface-raised);border:2px solid var(--accent-primary);box-shadow:var(--shadow-sm);transition:transform 140ms ease}.range:hover::-webkit-slider-thumb{transform:scale(1.2)}
+      .range-tip{position:absolute;top:-28px;left:var(--fill,35%);transform:translateX(-50%);font-size:.78rem;background:var(--surface-overlay);padding:3px 8px;border-radius:999px;border:1px solid var(--border-subtle)}
+
+      .mini-toggle{display:flex;align-items:center;gap:10px}.switch{width:40px;height:22px;border-radius:999px;background:var(--border-default);padding:2px;position:relative;cursor:pointer}.switch::before{content:'';width:18px;height:18px;border-radius:50%;background:var(--surface-overlay);position:absolute;left:2px;top:2px;transition:transform 220ms cubic-bezier(0.34,1.56,0.64,1)}
+      .switch[aria-checked='true']{background:var(--accent-primary)}.switch[aria-checked='true']::before{transform:translateX(18px)}
+
+      .textarea-control{resize:none;overflow:hidden;min-height:90px}.counter{text-align:right;font-size:.75rem;color:var(--text-tertiary)}
+      .counter.warn{color:var(--accent-warning)} .counter.danger{color:var(--accent-error)}
+
+      .toasts{position:fixed;right:16px;bottom:16px;display:grid;gap:10px;z-index:var(--z-toast)}
+      .toast{min-width:280px;background:var(--surface-overlay);border:1px solid var(--border-subtle);border-left:4px solid var(--accent-primary);padding:12px;border-radius:12px;box-shadow:var(--shadow-md);animation:toastIn .28s ease-out}
+      .toast.exit{animation:toastOut .22s ease-in forwards}.progress{height:3px;background:var(--accent-primary);margin-top:8px;transform-origin:left;animation:drain 4s linear forwards}
+
+      .skeleton{display:grid;gap:10px}.sk{height:14px;border-radius:8px;background:linear-gradient(110deg,var(--surface-sunken) 8%,color-mix(in srgb,var(--surface-sunken) 60%,#fff) 18%,var(--surface-sunken) 33%);background-size:200% 100%;animation:shimmer 1.2s linear infinite}
+
+      [data-tooltip]{position:relative}.tooltip{position:absolute;max-width:220px;background:var(--surface-overlay);border:1px solid var(--border-subtle);padding:8px 10px;border-radius:10px;box-shadow:var(--shadow-sm);font-size:.8rem;opacity:0;transform:translateY(8px);pointer-events:none;z-index:var(--z-tooltip)}
+      .tooltip.show{opacity:1;transform:translateY(0)}
+
+      .result{opacity:0;transform:scale(.95);background:var(--surface-raised);border:1px solid var(--border-subtle);border-radius:14px;padding:16px}
+      .result.show{opacity:1;transform:scale(1);animation:reveal .3s ease,shadowBreath .5s ease}
+      .value{font-family:'JetBrains Mono',monospace;font-size:1.8rem}
+
+      table{width:100%;border-collapse:collapse;font-size:.84rem}th,td{padding:8px;border-bottom:1px solid var(--border-subtle)}.swatch{width:20px;height:20px;border-radius:6px;border:1px solid var(--border-subtle);display:inline-block;vertical-align:middle;margin-right:6px}
+
+      @keyframes spin{to{transform:rotate(360deg)}} @keyframes shake{20%{transform:translateX(-5px)}40%{transform:translateX(5px)}60%{transform:translateX(-4px)}80%{transform:translateX(4px)}}
+      @keyframes draw{to{stroke-dashoffset:0}} @keyframes toastIn{from{opacity:0;transform:translateX(100%)}to{opacity:1;transform:translateX(0)}} @keyframes toastOut{to{opacity:0;transform:translateX(110%)}}
+      @keyframes drain{to{transform:scaleX(0)}} @keyframes shimmer{to{background-position:-200% 0}} @keyframes fadeSlide{from{opacity:0;transform:translateY(-8px)}to{opacity:1;transform:translateY(0)}}
+      @keyframes reveal{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}} @keyframes shadowBreath{50%{box-shadow:var(--shadow-glow)}}
+      @keyframes twinkle{50%{opacity:.2}}
+      @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation-duration:.01ms !important;transition-duration:.01ms !important}}
+    </style>
+  </head>
+  <body>
+    <main class="demo">
+      <section class="card">
+        <h1>Style Guide Interativo</h1>
+        <h2>1) Theme Toggle</h2>
+        <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo escuro" aria-pressed="false"><span class="theme-thumb">☀️</span><span class="theme-star" style="left:38px;top:8px"></span><span class="theme-star" style="left:31px;top:14px"></span></button>
+      </section>
+      <section class="card">
+        <h2>2) Inputs</h2>
+        <div class="grid">
+          <div>
+            <div class="input-wrapper" id="nameWrap"><label class="input-label">Nome completo</label><div class="input-field"><input class="input-control" id="nameInput" /><span class="status-icon error-icon">❌</span><span class="status-icon success-icon"><svg viewBox="0 0 16 16"><path d="M2 8l4 4 8-8"/></svg></span><span class="status-icon loader"></span></div><div class="hint" role="alert"></div></div>
+            <div style="display:flex;gap:8px;margin-top:8px"><button data-state="error">Erro</button><button data-state="success">Sucesso</button><button data-state="loading">Loading</button></div>
+          </div>
+          <div class="custom-select" id="customSelect"><button class="select-trigger" type="button">Escolha uma opção <span class="chevron">⌄</span></button><div class="select-menu"><div class="option">Diário</div><div class="option">Semanal</div><div class="option">Mensal</div></div></div>
+          <div class="range-wrap"><input class="range" id="range" type="range" min="0" max="100" value="35" /><span class="range-tip" id="rangeTip">35%</span></div>
+          <div class="mini-toggle"><button class="switch" role="switch" aria-checked="false" id="miniSwitch"></button><span>Receber notificações</span></div>
+          <div><div class="input-wrapper is-filled"><label class="input-label" style="top:16px;transform:none;font-size:.72rem">Mensagem</label><div class="input-field"><textarea id="txt" class="textarea-control" maxlength="500"></textarea></div></div><div class="counter" id="counter">0 / 500</div></div>
+          <div><div class="input-wrapper is-filled"><label class="input-label" style="top:16px;transform:none;font-size:.72rem">Preço</label><div class="input-field"><span>R$</span><input class="input-control" type="number" value="125" /><span>/mês</span></div></div></div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>3) Feedback Components</h2>
+        <div style="display:flex;gap:8px;flex-wrap:wrap"><button data-toast="success">Toast Success</button><button data-toast="error">Toast Error</button><button data-toast="info">Toast Info</button><button data-toast="warning">Toast Warning</button></div>
+        <div class="grid" style="margin-top:12px"><div class="skeleton"><div class="sk" style="width:55%"></div><div class="sk"></div><div class="sk" style="width:72%"></div></div><button data-tooltip="Tooltip profissional com delay de 400ms" id="tipBtn">Passe o mouse no tooltip</button></div>
+      </section>
+      <section class="card">
+        <h2>4) Resultado de cálculo</h2>
+        <button id="calcBtn">Calcular</button>
+        <div class="result" id="resultCard"><div>Linha 1</div><div class="value" id="resultValue">0</div><div>Linha 2</div></div>
+      </section>
+      <section class="card">
+        <h2>5) Token Reference</h2>
+        <table><thead><tr><th>Token</th><th>Valor atual</th></tr></thead><tbody id="tokenTable"></tbody></table>
+      </section>
+    </main>
+    <div class="toasts" id="toasts"></div>
+    <script>
+      const root = document.documentElement;
+      const pref = localStorage.getItem('theme');
+      const system = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      root.dataset.theme = pref || system || 'light';
+      const themeToggle = document.getElementById('themeToggle');
+      const thumb = themeToggle.querySelector('.theme-thumb');
+      const syncTheme = () => {
+        const dark = root.dataset.theme === 'dark';
+        themeToggle.setAttribute('aria-pressed', dark);
+        thumb.textContent = dark ? '🌙' : '☀️';
+        localStorage.setItem('theme', root.dataset.theme);
+        renderTokens();
+      };
+      themeToggle.onclick = () => { root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark'; syncTheme(); };
+      syncTheme();
+
+      const wrap = document.getElementById('nameWrap');
+      const input = document.getElementById('nameInput');
+      const hint = wrap.querySelector('.hint');
+      input.addEventListener('input', () => wrap.classList.toggle('is-filled', !!input.value.trim()));
+      input.addEventListener('blur', () => {
+        if (!input.value.trim()) {
+          wrap.className = 'input-wrapper is-error';
+          hint.textContent = 'Conte para nós como devemos te chamar.';
+        } else if (input.value.trim().length > 2) {
+          wrap.className = 'input-wrapper is-filled is-success';
+          hint.textContent = 'Perfeito, seu nome parece ótimo.';
+          hint.style.color = 'var(--accent-success)';
+        }
+      });
+      document.querySelectorAll('[data-state]').forEach((btn) => btn.addEventListener('click', () => {
+        wrap.className = `input-wrapper is-filled is-${btn.dataset.state}`;
+        hint.style.color = btn.dataset.state === 'error' ? 'var(--accent-error)' : 'var(--text-tertiary)';
+        hint.textContent = btn.dataset.state === 'error' ? 'Nome precisa ter no mínimo 3 caracteres.' : `Estado ${btn.dataset.state} aplicado.`;
+      }));
+
+      const select = document.getElementById('customSelect');
+      select.querySelector('.select-trigger').onclick = () => select.classList.toggle('open');
+      select.querySelectorAll('.option').forEach((opt) => opt.onclick = () => { select.querySelector('.select-trigger').childNodes[0].textContent = opt.textContent + ' '; select.classList.remove('open'); });
+
+      const range = document.getElementById('range');
+      const rangeTip = document.getElementById('rangeTip');
+      const syncRange = () => { range.style.setProperty('--fill', range.value + '%'); rangeTip.style.left = range.value + '%'; rangeTip.textContent = range.value + '%'; };
+      range.oninput = syncRange; syncRange();
+
+      const sw = document.getElementById('miniSwitch');
+      sw.onclick = () => sw.setAttribute('aria-checked', String(sw.getAttribute('aria-checked') !== 'true'));
+
+      const txt = document.getElementById('txt');
+      const counter = document.getElementById('counter');
+      txt.addEventListener('input', () => {
+        txt.style.height = 'auto'; txt.style.height = txt.scrollHeight + 'px';
+        const l = txt.value.length; counter.textContent = `${l} / 500`;
+        counter.className = 'counter' + (l > 420 ? ' danger' : l > 360 ? ' warn' : '');
+      });
+
+      const toasts = document.getElementById('toasts');
+      document.querySelectorAll('[data-toast]').forEach((btn) => btn.onclick = () => {
+        const type = btn.dataset.toast; const toast = document.createElement('div'); toast.className = 'toast';
+        toast.style.borderLeftColor = `var(--accent-${type === 'info' ? 'primary' : type})`;
+        toast.innerHTML = `<strong>${type.toUpperCase()}</strong><div>Notificação ${type} enviada com animação.</div><div class='progress'></div>`;
+        toasts.prepend(toast);
+        setTimeout(() => toast.classList.add('exit'), 3800);
+        setTimeout(() => toast.remove(), 4200);
+      });
+
+      const tipBtn = document.getElementById('tipBtn');
+      let tipTimer;
+      tipBtn.addEventListener('mouseenter', () => {
+        tipTimer = setTimeout(() => {
+          const tip = document.createElement('div'); tip.className = 'tooltip show'; tip.textContent = tipBtn.dataset.tooltip;
+          document.body.appendChild(tip);
+          const rect = tipBtn.getBoundingClientRect(); const top = rect.top > 80 ? rect.top - tip.offsetHeight - 8 : rect.bottom + 8;
+          tip.style.left = Math.min(window.innerWidth - 240, rect.left) + 'px'; tip.style.top = top + 'px'; tipBtn._tip = tip;
+        }, 400);
+      });
+      tipBtn.addEventListener('mouseleave', () => { clearTimeout(tipTimer); tipBtn._tip?.remove(); });
+
+      const calcBtn = document.getElementById('calcBtn'); const resultCard = document.getElementById('resultCard'); const resultValue = document.getElementById('resultValue');
+      calcBtn.onclick = () => {
+        resultCard.classList.add('show');
+        const target = 4832; const start = performance.now();
+        const tick = (now) => {
+          const p = Math.min((now - start) / 600, 1);
+          resultValue.textContent = Math.round(target * p).toLocaleString('pt-BR');
+          if (p < 1) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      };
+
+      const tokenList = ['surface-base','surface-raised','surface-overlay','surface-sunken','text-primary','text-secondary','text-tertiary','border-default','border-strong','accent-primary','accent-success','accent-error','accent-warning'];
+      function renderTokens(){
+        const styles = getComputedStyle(root); document.getElementById('tokenTable').innerHTML = tokenList.map((t)=>`<tr><td>--${t}</td><td><span class='swatch' style='background:${styles.getPropertyValue('--'+t)}'></span>${styles.getPropertyValue('--'+t)}</td></tr>`).join('');
+      }
+      renderTokens();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,14 @@
       crossOrigin="anonymous"
     ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      (() => {
+        const savedTheme = localStorage.getItem('theme');
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        const initialTheme = savedTheme === 'dark' || savedTheme === 'light' ? savedTheme : systemTheme;
+        document.documentElement.dataset.theme = initialTheme;
+      })();
+    </script>
     <title>Calcule ja</title>
   </head>
   <body>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,6 +8,8 @@ import {
   Beaker,
   Receipt,
   Wallet,
+  Moon,
+  Sun,
 } from 'lucide-react';
 import React from 'react';
 import Footer from './Footer';
@@ -36,7 +38,23 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
+const getSystemTheme = () =>
+  window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
 export const Layout: React.FC<LayoutProps> = ({ activeTab, setActiveTab, children }) => {
+  const [theme, setTheme] = React.useState<'light' | 'dark'>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'light' || savedTheme === 'dark') return savedTheme;
+    return getSystemTheme();
+  });
+
+  React.useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((currentTheme) => (currentTheme === 'dark' ? 'light' : 'dark'));
+
   return (
     <div className="min-h-screen app-shell pb-24 md:pb-0">
       <header className="app-header">
@@ -44,7 +62,23 @@ export const Layout: React.FC<LayoutProps> = ({ activeTab, setActiveTab, childre
           <p className="app-kicker">Ferramentas de cálculo</p>
           <h1 className="app-title">Calcule Já</h1>
         </div>
-        <p className="app-subtitle">Precisão rápida para decisões do dia a dia.</p>
+        <div className="header-actions">
+          <p className="app-subtitle">Precisão rápida para decisões do dia a dia.</p>
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label="Alternar modo escuro"
+            aria-pressed={theme === 'dark'}
+          >
+            <span className="theme-toggle-track" aria-hidden="true">
+              <span className="theme-toggle-thumb">
+                <Sun className="theme-icon sun-icon" size={13} />
+                <Moon className="theme-icon moon-icon" size={13} />
+              </span>
+            </span>
+          </button>
+        </div>
       </header>
 
       <div className="app-grid">

--- a/src/index.css
+++ b/src/index.css
@@ -1,37 +1,141 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Bebas+Neue&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Bebas+Neue&family=JetBrains+Mono:wght@500;700&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+:root,
+:root[data-theme='light'] {
+  --surface-base: #f7f7f5;
+  --surface-raised: #ffffff;
+  --surface-overlay: #ffffff;
+  --surface-sunken: #eff0ea;
+
+  --text-primary: #131313;
+  --text-secondary: #51515c;
+  --text-tertiary: #8e90a1;
+  --text-disabled: #b1b3c2;
+  --text-inverse: #10111b;
+
+  --border-subtle: #d8dbe6;
+  --border-default: #c3c8d5;
+  --border-strong: #7087ff;
+  --border-accent: #5f76ef;
+
+  --accent-primary: #5f76ef;
+  --accent-primary-dim: rgba(95, 118, 239, 0.2);
+  --accent-success: #1f9a6e;
+  --accent-error: #db4a62;
+  --accent-warning: #d99519;
+
+  --shadow-sm: 0 10px 24px rgba(66, 80, 135, 0.12);
+  --shadow-md: 0 26px 60px rgba(57, 68, 125, 0.18);
+  --shadow-glow: 0 0 0 1px rgba(95, 118, 239, 0.35), 0 12px 34px rgba(95, 118, 239, 0.18);
+
+  --theme-toggle-track-start: #74c8ff;
+  --theme-toggle-track-end: #9ca7ff;
+  --theme-toggle-star: #ffffff;
+
+  --z-base: 0;
+  --z-raised: 10;
+  --z-dropdown: 100;
+  --z-sticky: 200;
+  --z-modal: 300;
+  --z-toast: 400;
+  --z-tooltip: 500;
+}
+
+:root[data-theme='dark'] {
+  --surface-base: #0f1117;
+  --surface-raised: #171a22;
+  --surface-overlay: #1e222b;
+  --surface-sunken: #12151d;
+
+  --text-primary: #edeee8;
+  --text-secondary: #adb1c4;
+  --text-tertiary: #7b8099;
+  --text-disabled: #5f667f;
+  --text-inverse: #f0f1f8;
+
+  --border-subtle: #2a2e3d;
+  --border-default: #343a4c;
+  --border-strong: #8f9eff;
+  --border-accent: #8f9eff;
+
+  --accent-primary: #8f9eff;
+  --accent-primary-dim: rgba(143, 158, 255, 0.24);
+  --accent-success: #33bf8d;
+  --accent-error: #ff6a80;
+  --accent-warning: #f2ba49;
+
+  --shadow-sm: 0 12px 30px rgba(5, 7, 14, 0.55);
+  --shadow-md: 0 34px 70px rgba(3, 4, 9, 0.78);
+  --shadow-glow: 0 0 0 1px rgba(143, 158, 255, 0.38), 0 20px 50px rgba(82, 96, 194, 0.3);
+
+  --theme-toggle-track-start: #39479f;
+  --theme-toggle-track-end: #7f4fd4;
+  --theme-toggle-star: #f8f8ff;
+}
+
 @layer base {
-  :root {
-    --color-bg: #0a0f1f;
-    --color-surface: #141b31;
-    --color-primary: #4cc9f0;
-    --color-accent: #ff9e00;
-    --color-text: #f2f5ff;
-  }
-
-  * {
+  *,
+  *::before,
+  *::after {
     @apply border-border;
+    transition: background-color 220ms ease, border-color 220ms ease, color 160ms ease, box-shadow 220ms ease;
   }
 
+  img,
+  video,
+  [data-no-transition] {
+    transition: none;
+  }
+
+  *:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+  }
+
+  *::selection {
+    background: var(--accent-primary-dim);
+    color: var(--text-primary);
+  }
+
+  html,
   body {
     margin: 0;
+    min-height: 100%;
     font-family: 'Space Grotesk', sans-serif;
-    color: var(--color-text);
+    color: var(--text-primary);
     background:
-      radial-gradient(circle at 10% 10%, rgba(76, 201, 240, 0.18), transparent 40%),
-      radial-gradient(circle at 90% 20%, rgba(255, 158, 0, 0.2), transparent 40%),
-      repeating-linear-gradient(
-        140deg,
-        rgba(255, 255, 255, 0.02) 0,
-        rgba(255, 255, 255, 0.02) 2px,
-        transparent 2px,
-        transparent 12px
-      ),
-      var(--color-bg);
+      radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--accent-primary) 12%, transparent), transparent 42%),
+      radial-gradient(circle at 85% 8%, color-mix(in srgb, var(--accent-warning) 11%, transparent), transparent 38%),
+      radial-gradient(circle, color-mix(in srgb, var(--text-secondary) 10%, transparent) 1px, transparent 1px),
+      var(--surface-base);
+    background-size: auto, auto, 20px 20px, auto;
+    background-attachment: fixed;
+  }
+
+  :root[data-theme='dark'] body {
+    background:
+      radial-gradient(circle at 20% 20%, rgba(143, 158, 255, 0.09), transparent 45%),
+      radial-gradient(circle at 90% 0%, rgba(159, 116, 255, 0.08), transparent 38%),
+      radial-gradient(circle at 50% 100%, rgba(51, 191, 141, 0.06), transparent 43%),
+      var(--surface-base);
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-primary) 45%, var(--surface-overlay));
+    border: 2px solid var(--surface-base);
+  }
+
+  ::placeholder {
+    color: var(--text-tertiary);
   }
 }
 
@@ -44,18 +148,120 @@
     @apply mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between;
   }
 
+  .header-actions {
+    @apply flex items-center gap-4;
+  }
+
   .app-kicker {
-    @apply text-xs uppercase tracking-[0.2em] text-cyan-200/80;
+    letter-spacing: 0.2em;
+    color: var(--text-secondary);
+    @apply text-xs uppercase;
   }
 
   .app-title {
     font-family: 'Bebas Neue', cursive;
     letter-spacing: 0.08em;
-    @apply text-6xl leading-none text-white;
+    color: var(--text-primary);
+    @apply text-6xl leading-none;
   }
 
   .app-subtitle {
-    @apply max-w-sm text-sm text-slate-300;
+    color: var(--text-secondary);
+    @apply max-w-sm text-sm;
+  }
+
+  .theme-toggle {
+    width: 52px;
+    height: 28px;
+    border-radius: 999px;
+    background: linear-gradient(130deg, var(--theme-toggle-track-start), var(--theme-toggle-track-end));
+    border: 1px solid var(--border-subtle);
+    padding: 2px;
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 24 24'%3E%3Ctext y='17' font-size='16'%3E%E2%98%80%EF%B8%8F%3C/text%3E%3C/svg%3E") 4 4, pointer;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .theme-toggle-track {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .theme-toggle-track::before,
+  .theme-toggle-track::after {
+    content: '';
+    position: absolute;
+    width: 3px;
+    height: 3px;
+    border-radius: 999px;
+    background: var(--theme-toggle-star);
+    opacity: 0;
+    transform: translateY(3px);
+    transition: opacity 220ms ease, transform 220ms ease;
+  }
+
+  .theme-toggle-track::before {
+    top: 6px;
+    right: 14px;
+  }
+
+  .theme-toggle-track::after {
+    top: 14px;
+    right: 8px;
+  }
+
+  .theme-toggle-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    display: grid;
+    place-items: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: var(--surface-raised);
+    transform: translateX(0);
+    transition: transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .theme-icon {
+    position: absolute;
+    transition: transform 220ms ease, opacity 180ms ease;
+  }
+
+  .moon-icon {
+    opacity: 0;
+    transform: scale(0.6) rotate(30deg);
+  }
+
+  :root[data-theme='dark'] .theme-toggle {
+    background: linear-gradient(130deg, var(--theme-toggle-track-start), var(--theme-toggle-track-end));
+    cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 24 24'%3E%3Ctext y='17' font-size='16'%3E%F0%9F%8C%99%3C/text%3E%3C/svg%3E") 4 4, pointer;
+  }
+
+  :root[data-theme='dark'] .theme-toggle-thumb {
+    transform: translateX(24px);
+  }
+
+  :root[data-theme='dark'] .sun-icon {
+    opacity: 0;
+    transform: scale(0.5) rotate(-15deg);
+  }
+
+  :root[data-theme='dark'] .moon-icon {
+    opacity: 1;
+    transform: scale(1) rotate(0);
+  }
+
+  :root[data-theme='dark'] .theme-toggle-track::before,
+  :root[data-theme='dark'] .theme-toggle-track::after {
+    opacity: 0.82;
+    transform: translateY(0);
   }
 
   .app-grid {
@@ -65,9 +271,9 @@
   .sidebar,
   .main-panel,
   .footer-shell {
-    background: linear-gradient(160deg, rgba(20, 27, 49, 0.92), rgba(9, 14, 28, 0.94));
-    border: 1px solid rgba(76, 201, 240, 0.18);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+    background: linear-gradient(160deg, color-mix(in srgb, var(--surface-raised) 92%, transparent), var(--surface-sunken));
+    border: 1px solid var(--border-subtle);
+    box-shadow: var(--shadow-sm);
     @apply rounded-2xl backdrop-blur;
   }
 
@@ -76,7 +282,9 @@
   }
 
   .sidebar-title {
-    @apply mb-3 text-xs uppercase tracking-[0.18em] text-cyan-100/70;
+    letter-spacing: 0.18em;
+    color: var(--text-tertiary);
+    @apply mb-3 text-xs uppercase;
   }
 
   .sidebar-nav {
@@ -85,21 +293,23 @@
 
   .nav-item,
   .mobile-nav-item {
-    @apply flex w-full items-center gap-2 rounded-xl border border-transparent px-3 py-2 text-left text-sm text-slate-200 transition duration-300;
+    color: var(--text-secondary);
+    @apply flex w-full items-center gap-2 rounded-xl border border-transparent px-3 py-2 text-left text-sm transition duration-300;
   }
 
   .nav-item:hover,
   .mobile-nav-item:hover {
     transform: translateX(4px);
-    border-color: rgba(76, 201, 240, 0.5);
-    background: rgba(76, 201, 240, 0.08);
+    border-color: var(--border-strong);
+    background: var(--accent-primary-dim);
+    color: var(--text-primary);
   }
 
   .nav-item-active,
   .mobile-nav-item-active {
-    border-color: rgba(255, 158, 0, 0.8);
-    background: rgba(255, 158, 0, 0.14);
-    color: white;
+    border-color: color-mix(in srgb, var(--accent-warning) 60%, var(--accent-primary));
+    background: color-mix(in srgb, var(--accent-warning) 24%, transparent);
+    color: var(--text-primary);
   }
 
   .main-panel {
@@ -107,7 +317,10 @@
   }
 
   .mobile-nav {
-    @apply fixed bottom-2 left-1/2 z-20 flex w-[95%] -translate-x-1/2 gap-1 overflow-x-auto rounded-2xl border border-cyan-300/30 bg-slate-950/85 p-2 backdrop-blur;
+    z-index: var(--z-sticky);
+    background: color-mix(in srgb, var(--surface-overlay) 89%, transparent);
+    border: 1px solid var(--border-default);
+    @apply fixed bottom-2 left-1/2 flex w-[95%] -translate-x-1/2 gap-1 overflow-x-auto rounded-2xl p-2 backdrop-blur;
   }
 
   .mobile-nav-item {
@@ -121,48 +334,59 @@
   .calc-stage h2 {
     font-family: 'Bebas Neue', cursive;
     letter-spacing: 0.06em;
-    @apply text-4xl text-white;
+    color: var(--text-primary);
+    @apply text-4xl;
   }
 
   .calc-stage label,
   .calc-stage p,
   .calc-stage span,
   .calc-stage h3 {
-    @apply text-slate-100;
+    color: var(--text-secondary);
   }
 
   .calc-stage input,
   .calc-stage select,
   .app-input,
   .calc-stage textarea {
-    @apply w-full rounded-xl border border-cyan-300/25 bg-slate-900/70 px-4 py-2 text-slate-50 outline-none transition;
+    background: var(--surface-sunken);
+    border-color: var(--border-default);
+    color: var(--text-primary);
+    @apply w-full rounded-xl border px-4 py-2 outline-none;
   }
 
   .calc-stage input:focus,
   .calc-stage select:focus,
   .app-input:focus,
   .calc-stage textarea:focus {
-    box-shadow: 0 0 0 3px rgba(76, 201, 240, 0.2);
-    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--accent-primary-dim);
+    border-color: var(--border-strong);
   }
 
   .calc-stage button,
   .app-button {
-    @apply rounded-xl border border-cyan-200/40 px-4 py-2 font-semibold text-white transition;
-    background: linear-gradient(120deg, #1a9ec5, #246fb8);
+    border: 1px solid color-mix(in srgb, var(--accent-primary) 50%, var(--border-default));
+    background: linear-gradient(120deg, color-mix(in srgb, var(--accent-primary) 82%, var(--surface-overlay)), color-mix(in srgb, var(--accent-primary) 60%, var(--surface-base)));
+    color: var(--text-inverse);
+    @apply rounded-xl px-4 py-2 font-semibold;
   }
 
   .calc-stage button:hover,
   .app-button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(76, 201, 240, 0.3);
+    box-shadow: var(--shadow-glow);
   }
 
   .result-card {
-    border: 1px solid rgba(255, 158, 0, 0.45);
-    background: rgba(255, 158, 0, 0.08);
+    border: 1px solid color-mix(in srgb, var(--accent-warning) 70%, transparent);
+    background: color-mix(in srgb, var(--accent-warning) 12%, transparent);
     animation: pulseCard 2.2s ease-in-out infinite;
     @apply rounded-xl p-5;
+  }
+
+  .result-card strong,
+  .result-card h3 {
+    font-family: 'JetBrains Mono', monospace;
   }
 
   .footer-shell {
@@ -174,19 +398,23 @@
   }
 
   .footer-title {
-    @apply mb-2 text-lg font-bold text-white;
+    color: var(--text-primary);
+    @apply mb-2 text-lg font-bold;
   }
 
   .footer-text {
-    @apply text-sm text-slate-300;
+    color: var(--text-secondary);
+    @apply text-sm;
   }
 
   .footer-highlight {
-    @apply text-sm font-bold text-amber-300;
+    color: var(--accent-warning);
+    @apply text-sm font-bold;
   }
 
   .footer-link {
-    @apply text-cyan-300 underline;
+    color: var(--accent-primary);
+    @apply underline;
   }
 }
 
@@ -204,9 +432,20 @@
 @keyframes pulseCard {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(255, 158, 0, 0.15);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-warning) 24%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 10px rgba(255, 158, 0, 0);
+    box-shadow: 0 0 0 10px color-mix(in srgb, var(--accent-warning) 0%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a living style guide and developer demo while centralizing design tokens and adding a persistent light/dark theme to improve UI consistency and developer ergonomics.
- Surface interactive UI primitives (inputs, selects, range, toasts, tooltip) to validate styles and component behavior across themes.

### Description
- Add `demo-components.html` which implements a full interactive style guide and token reference showcasing inputs, custom select, range, toasts, tooltip, calculation animation and a token swatch table.
- Initialize the document theme early in `index.html` via an inline script to apply the saved `localStorage` preference or the system `prefers-color-scheme` before React mounts.
- Add theme state, persistence and a toggle button (Sun/Moon) to `src/components/Layout.tsx`, and wire `document.documentElement.dataset.theme` updates to persist the chosen theme.
- Overhaul `src/index.css` to introduce CSS custom properties for light/dark tokens, theme-toggle styles, and refactor component styles to use the new tokens and improved shadows, colors and transitions.

### Testing
- Ran `npm run build` and TypeScript typechecking locally and the build completed successfully.
- Ran `npm run lint` and linting passed without errors.
- No new unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1dce5ee04832c8b5018f8528e942b)